### PR TITLE
fix: app - Reset index of the pagination with search

### DIFF
--- a/edgar-app/src/components/dashboardPages/appointments/modals/UpdateAppointmentBody.tsx
+++ b/edgar-app/src/components/dashboardPages/appointments/modals/UpdateAppointmentBody.tsx
@@ -34,7 +34,14 @@ const UpdateAppointmentBody = ({
 	return (
 		<VStack w="100%" spacing="16px">
 			<InputGroup>
-				<Input placeholder="Docteur Edgar" maxLength={100} onChange={(e) => setSearchValue(e.target.value)} />
+				<Input
+					placeholder="Docteur Edgar"
+					maxLength={100}
+					onChange={(e) => {
+						setPageIndex(1);
+						setSearchValue(e.target.value);
+					}}
+				/>
 				<InputRightElement>
 					<Icon as={SearchIcon} />
 				</InputRightElement>

--- a/edgar-app/src/components/dashboardPages/chat/modals/SelectDoctorContent.tsx
+++ b/edgar-app/src/components/dashboardPages/chat/modals/SelectDoctorContent.tsx
@@ -37,7 +37,14 @@ const SelectDoctorContent = ({ onClick }: { onClick: (doctorInfos: DoctorType) =
 	return (
 		<VStack w="100%" spacing="24px">
 			<InputGroup>
-				<Input placeholder="Nom du médecin" maxLength={100} onChange={(e) => setSearchValue(e.target.value)} />
+				<Input
+					placeholder="Nom du médecin"
+					maxLength={100}
+					onChange={(e) => {
+						setPageIndex(1);
+						setSearchValue(e.target.value);
+					}}
+				/>
 				<InputRightElement>
 					<Icon as={SearchIcon} />
 				</InputRightElement>

--- a/edgar-app/src/components/onboardingPages/personal/primaryDoctor/SelectPrimaryDoctorContent.tsx
+++ b/edgar-app/src/components/onboardingPages/personal/primaryDoctor/SelectPrimaryDoctorContent.tsx
@@ -33,7 +33,14 @@ const SelectPrimaryDoctorContent = ({
 	return (
 		<VStack w="100%" spacing="24px">
 			<InputGroup>
-				<Input placeholder="Nom du médecin" maxLength={100} onChange={(e) => setSearchValue(e.target.value)} />
+				<Input
+					placeholder="Nom du médecin"
+					maxLength={100}
+					onChange={(e) => {
+						setPageIndex(1);
+						setSearchValue(e.target.value);
+					}}
+				/>
 				<InputRightElement>
 					<Icon as={SearchIcon} />
 				</InputRightElement>


### PR DESCRIPTION
# Description

- When the result paginated is filtered with a search, the index of the pagination is reset to avoid no display of the results due to bad index page

### Click Up reference

[CU-86c0j93dr](https://app.clickup.com/t/86c0j93dr)

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the needed labels
- [X] I have linked this PR to a clickup task
- [X] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs