### PR TITLE
fix: app & pro - Update page name in useEffect for backup code generation

### DIFF
--- a/edgar-app/src/components/settingsModals/pages/account/SettingsAccount2FA3rdPartyEnableBackupCodesPage.tsx
+++ b/edgar-app/src/components/settingsModals/pages/account/SettingsAccount2FA3rdPartyEnableBackupCodesPage.tsx
@@ -29,7 +29,7 @@ const SettingsAccount2FA3rdPartyEnableBackupCodesPage = (
 	const toast = useToast({ duration: 3000, isClosable: true });
 
 	useEffect(() => {
-		if (selectedPageStack[selectedPageStack.length - 1] !== 'settingsAccount2fa3rdPartyEnableBackupCode') return;
+		if (selectedPageStack[selectedPageStack.length - 1] !== 'settingsAccount2fa3rdPartyEnableBackupCodes') return;
 		triggerGenerateBackupCodes()
 			.unwrap()
 			.then((res) => setBackupCodes(res))

--- a/edgar-doctor/src/components/settingsModals/pages/account/SettingsAccount2FA3rdPartyEnableBackupCodesPage.tsx
+++ b/edgar-doctor/src/components/settingsModals/pages/account/SettingsAccount2FA3rdPartyEnableBackupCodesPage.tsx
@@ -29,7 +29,7 @@ const SettingsAccount2FA3rdPartyEnableBackupCodesPage = (
 	const toast = useToast({ duration: 3000, isClosable: true });
 
 	useEffect(() => {
-		if (selectedPageStack[selectedPageStack.length - 1] !== 'settingsAccount2fa3rdPartyEnableBackupCode') return;
+		if (selectedPageStack[selectedPageStack.length - 1] !== 'settingsAccount2fa3rdPartyEnableBackupCodes') return;
 		triggerGenerateBackupCodes()
 			.unwrap()
 			.then((res) => setBackupCodes(res))


### PR DESCRIPTION
# Description

- Add missing "s" in the useEffect to trigger the backend call to generate the backup code when the page is opened

### Click Up reference

[CU-86c0jhphp](https://app.clickup.com/t/86c0jhphp)

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the needed labels
- [X] I have linked this PR to a clickup task
- [X] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs