### PR TITLE
fix: Update auth route with user type

### DIFF
--- a/edgar-app/src/services/request/account.ts
+++ b/edgar-app/src/services/request/account.ts
@@ -6,7 +6,7 @@ const extendedApi = backendApi.injectEndpoints({
 	endpoints: (builder) => ({
 		missingPassword: builder.mutation<void, MissingPasswordDTO>({
 			query: (params) => ({
-				url: '/auth/missing-password',
+				url: '/auth/p/missing-password',
 				method: 'POST',
 				body: {
 					email: params.email,
@@ -15,7 +15,7 @@ const extendedApi = backendApi.injectEndpoints({
 		}),
 		resetPassword: builder.mutation<void, ResetPasswordDTO>({
 			query: (params) => ({
-				url: `/auth/reset-password?uuid=${params.uuid}`,
+				url: `/auth/p/reset-password?uuid=${params.uuid}`,
 				method: 'POST',
 				body: {
 					new_password: params.password,

--- a/edgar-app/src/services/request/login.ts
+++ b/edgar-app/src/services/request/login.ts
@@ -6,7 +6,7 @@ const extendedApi = backendApi.injectEndpoints({
 	endpoints: (builder) => ({
 		sendLogin2faEmail: builder.mutation<void, string>({
 			query: (email) => ({
-				url: '/auth/p/sending_email',
+				url: '/auth/sending_email',
 				method: 'POST',
 				body: {
 					email,

--- a/edgar-doctor/src/services/request/account.ts
+++ b/edgar-doctor/src/services/request/account.ts
@@ -6,7 +6,7 @@ const extendedApi = backendApi.injectEndpoints({
 	endpoints: (builder) => ({
 		missingPassword: builder.mutation<void, MissingPasswordDTO>({
 			query: (params) => ({
-				url: '/auth/missing-password',
+				url: '/auth/d/missing-password',
 				method: 'POST',
 				body: {
 					email: params.email,
@@ -16,7 +16,7 @@ const extendedApi = backendApi.injectEndpoints({
 
 		resetPassword: builder.mutation<void, ResetPasswordDTO>({
 			query: (params) => ({
-				url: `/auth/reset-password?uuid=${params.uuid}`,
+				url: `/auth/d/reset-password?uuid=${params.uuid}`,
 				method: 'POST',
 				body: {
 					new_password: params.password,

--- a/edgar-doctor/src/services/request/login.ts
+++ b/edgar-doctor/src/services/request/login.ts
@@ -6,7 +6,7 @@ const extendedApi = backendApi.injectEndpoints({
 	endpoints: (builder) => ({
 		sendLogin2faEmail: builder.mutation<void, string>({
 			query: (email) => ({
-				url: '/auth/d/sending_email',
+				url: '/auth/sending_email',
 				method: 'POST',
 				body: {
 					email,


### PR DESCRIPTION
# Description

- Update reset & missing password and send 2fa login email route with user type

### Click Up reference

[CU-86c13x1yj](https://app.clickup.com/t/86c13x1yj)

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the needed labels
- [X] I have linked this PR to a clickup task
- [X] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs