### PR TITLE
fix: autoreload on 2fa

### DIFF
--- a/edgar-app/src/components/settingsModals/ModalPages.tsx
+++ b/edgar-app/src/components/settingsModals/ModalPages.tsx
@@ -65,6 +65,11 @@ const ModalPages = ({
 		if (enabled2faMethods) {
 			setIsBackupCodeGenerated(enabled2faMethods.isBackupCodeGenerated);
 			setIsAuthenticationEnabled(enabled2faMethods.enabledMethods.length > 0);
+			if (
+				selectedPageStack[selectedPageStack.length - 1] === 'settingsAccount2faEdgar' &&
+				!enabled2faMethods.enabledMethods.includes('MOBILE')
+			)
+				onPreviousPage();
 		}
 	}, [enabled2faMethods]);
 

--- a/edgar-app/src/components/settingsModals/pages/account/SettingsAccount2FA3rdPartyEnableBackupCodesPage.tsx
+++ b/edgar-app/src/components/settingsModals/pages/account/SettingsAccount2FA3rdPartyEnableBackupCodesPage.tsx
@@ -13,7 +13,7 @@ const SettingsAccount2FA3rdPartyEnableBackupCodesPage = (
 	selectedPageStack: string[],
 	onNext: () => void,
 ): SettingsPageType => {
-	const [backupCodes, setBackupCodes] = useState<string[]>([
+	const defaultBackupCodes = [
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
@@ -22,7 +22,10 @@ const SettingsAccount2FA3rdPartyEnableBackupCodesPage = (
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
-	]);
+		'XXXX XXXX',
+		'XXXX XXXX',
+	];
+	const [backupCodes, setBackupCodes] = useState<string[]>(defaultBackupCodes);
 
 	const [triggerGenerateBackupCodes] = useGenerateBackupCodesMutation();
 
@@ -46,7 +49,13 @@ const SettingsAccount2FA3rdPartyEnableBackupCodesPage = (
 		sections: [],
 		bodyContent: <BackupCodes backupCodes={backupCodes} />,
 		footerPrimaryButton: (
-			<Button w="100%" onClick={onNext}>
+			<Button
+				w="100%"
+				onClick={() => {
+					setBackupCodes(defaultBackupCodes);
+					onNext();
+				}}
+			>
 				Mes codes sont sauvegardés
 			</Button>
 		),

--- a/edgar-app/src/components/settingsModals/pages/account/SettingsAccount2FAEdgarEnableBackupCodePage.tsx
+++ b/edgar-app/src/components/settingsModals/pages/account/SettingsAccount2FAEdgarEnableBackupCodePage.tsx
@@ -13,7 +13,7 @@ const SettingsAccount2FAEdgarEnableBackupCodePage = (
 	selectedPageStack: string[],
 	onNext: () => void,
 ): SettingsPageType => {
-	const [backupCodes, setBackupCodes] = useState<string[]>([
+	const defaultBackupCodes = [
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
@@ -22,7 +22,10 @@ const SettingsAccount2FAEdgarEnableBackupCodePage = (
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
-	]);
+		'XXXX XXXX',
+		'XXXX XXXX',
+	];
+	const [backupCodes, setBackupCodes] = useState<string[]>(defaultBackupCodes);
 
 	const [triggerGenerateBackupCodes] = useGenerateBackupCodesMutation();
 
@@ -46,7 +49,13 @@ const SettingsAccount2FAEdgarEnableBackupCodePage = (
 		sections: [],
 		bodyContent: <BackupCodes backupCodes={backupCodes} />,
 		footerPrimaryButton: (
-			<Button w="100%" onClick={onNext}>
+			<Button
+				w="100%"
+				onClick={() => {
+					setBackupCodes(defaultBackupCodes);
+					onNext();
+				}}
+			>
 				Mes codes sont sauvegardés
 			</Button>
 		),

--- a/edgar-app/src/components/settingsModals/pages/account/SettingsAccount2FAEmailEnableBackupCodesPage.tsx
+++ b/edgar-app/src/components/settingsModals/pages/account/SettingsAccount2FAEmailEnableBackupCodesPage.tsx
@@ -13,7 +13,7 @@ const SettingsAccount2FAEmailEnableBackupCodesPage = (
 	selectedPageStack: string[],
 	onNext: () => void,
 ): SettingsPageType => {
-	const [backupCodes, setBackupCodes] = useState<string[]>([
+	const defaultBackupCodes = [
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
@@ -24,7 +24,8 @@ const SettingsAccount2FAEmailEnableBackupCodesPage = (
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
-	]);
+	];
+	const [backupCodes, setBackupCodes] = useState<string[]>(defaultBackupCodes);
 
 	const [triggerGenerateBackupCodes] = useGenerateBackupCodesMutation();
 
@@ -48,7 +49,13 @@ const SettingsAccount2FAEmailEnableBackupCodesPage = (
 		sections: [],
 		bodyContent: <BackupCodes backupCodes={backupCodes} />,
 		footerPrimaryButton: (
-			<Button w="100%" onClick={onNext}>
+			<Button
+				w="100%"
+				onClick={() => {
+					setBackupCodes(defaultBackupCodes);
+					onNext();
+				}}
+			>
 				Mes codes sont sauvegardés
 			</Button>
 		),

--- a/edgar-app/src/components/settingsModals/pages/account/SettingsAccountBackupCodesGeneratePage.tsx
+++ b/edgar-app/src/components/settingsModals/pages/account/SettingsAccountBackupCodesGeneratePage.tsx
@@ -10,7 +10,7 @@ import { useGenerateBackupCodesMutation } from 'services/request/2fa';
 import ShieldIllustration from 'assets/illustrations/ShieldIllustration';
 
 const SettingsAccountBackupCodesGeneratePage = (selectedPageStack: string[], onNext: () => void): SettingsPageType => {
-	const [backupCodes, setBackupCodes] = useState<string[]>([
+	const defaultBackupCodes = [
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
@@ -19,7 +19,10 @@ const SettingsAccountBackupCodesGeneratePage = (selectedPageStack: string[], onN
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
-	]);
+		'XXXX XXXX',
+		'XXXX XXXX',
+	];
+	const [backupCodes, setBackupCodes] = useState<string[]>(defaultBackupCodes);
 
 	const [triggerGenerateBackupCodes] = useGenerateBackupCodesMutation();
 
@@ -43,7 +46,13 @@ const SettingsAccountBackupCodesGeneratePage = (selectedPageStack: string[], onN
 		sections: [],
 		bodyContent: <BackupCodes backupCodes={backupCodes} />,
 		footerPrimaryButton: (
-			<Button w="100%" onClick={onNext}>
+			<Button
+				w="100%"
+				onClick={() => {
+					setBackupCodes(defaultBackupCodes);
+					onNext();
+				}}
+			>
 				Mes codes sont sauvegardés
 			</Button>
 		),

--- a/edgar-app/src/services/request/2fa.ts
+++ b/edgar-app/src/services/request/2fa.ts
@@ -67,7 +67,7 @@ const extendedApi = backendApi.injectEndpoints({
 				url: '/auth/creation_backup_code',
 				method: 'POST',
 			}),
-			invalidatesTags: ['patient2faBackupCodes'],
+			invalidatesTags: ['patient2faBackupCodes', 'patient2faMethod'],
 			transformResponse: (response: { double_auth: string[] }) => response.double_auth,
 		}),
 

--- a/edgar-doctor/src/components/settingsModals/ModalPages.tsx
+++ b/edgar-doctor/src/components/settingsModals/ModalPages.tsx
@@ -65,6 +65,11 @@ const ModalPages = ({
 		if (enabled2faMethods) {
 			setIsBackupCodeGenerated(enabled2faMethods.isBackupCodeGenerated);
 			setIsAuthenticationEnabled(enabled2faMethods.enabledMethods.length > 0);
+			if (
+				selectedPageStack[selectedPageStack.length - 1] === 'settingsAccount2faEdgar' &&
+				!enabled2faMethods.enabledMethods.includes('MOBILE')
+			)
+				onPreviousPage();
 		}
 	}, [enabled2faMethods]);
 

--- a/edgar-doctor/src/components/settingsModals/pages/account/SettingsAccount2FA3rdPartyEnableBackupCodesPage.tsx
+++ b/edgar-doctor/src/components/settingsModals/pages/account/SettingsAccount2FA3rdPartyEnableBackupCodesPage.tsx
@@ -13,7 +13,7 @@ const SettingsAccount2FA3rdPartyEnableBackupCodesPage = (
 	selectedPageStack: string[],
 	onNext: () => void,
 ): SettingsPageType => {
-	const [backupCodes, setBackupCodes] = useState<string[]>([
+	const defaultBackupCodes = [
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
@@ -22,7 +22,10 @@ const SettingsAccount2FA3rdPartyEnableBackupCodesPage = (
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
-	]);
+		'XXXX XXXX',
+		'XXXX XXXX',
+	];
+	const [backupCodes, setBackupCodes] = useState<string[]>(defaultBackupCodes);
 
 	const [triggerGenerateBackupCodes] = useGenerateBackupCodesMutation();
 
@@ -46,7 +49,13 @@ const SettingsAccount2FA3rdPartyEnableBackupCodesPage = (
 		sections: [],
 		bodyContent: <BackupCodes backupCodes={backupCodes} />,
 		footerPrimaryButton: (
-			<Button w="100%" onClick={onNext}>
+			<Button
+				w="100%"
+				onClick={() => {
+					setBackupCodes(defaultBackupCodes);
+					onNext();
+				}}
+			>
 				Mes codes sont sauvegardés
 			</Button>
 		),

--- a/edgar-doctor/src/components/settingsModals/pages/account/SettingsAccount2FAEdgarEnableBackupCodePage.tsx
+++ b/edgar-doctor/src/components/settingsModals/pages/account/SettingsAccount2FAEdgarEnableBackupCodePage.tsx
@@ -13,7 +13,7 @@ const SettingsAccount2FAEdgarEnableBackupCodePage = (
 	selectedPageStack: string[],
 	onNext: () => void,
 ): SettingsPageType => {
-	const [backupCodes, setBackupCodes] = useState<string[]>([
+	const defaultBackupCodes = [
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
@@ -22,7 +22,10 @@ const SettingsAccount2FAEdgarEnableBackupCodePage = (
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
-	]);
+		'XXXX XXXX',
+		'XXXX XXXX',
+	];
+	const [backupCodes, setBackupCodes] = useState<string[]>(defaultBackupCodes);
 
 	const [triggerGenerateBackupCodes] = useGenerateBackupCodesMutation();
 
@@ -46,7 +49,13 @@ const SettingsAccount2FAEdgarEnableBackupCodePage = (
 		sections: [],
 		bodyContent: <BackupCodes backupCodes={backupCodes} />,
 		footerPrimaryButton: (
-			<Button w="100%" onClick={onNext}>
+			<Button
+				w="100%"
+				onClick={() => {
+					setBackupCodes(defaultBackupCodes);
+					onNext();
+				}}
+			>
 				Mes codes sont sauvegardés
 			</Button>
 		),

--- a/edgar-doctor/src/components/settingsModals/pages/account/SettingsAccount2FAEmailEnableBackupCodesPage.tsx
+++ b/edgar-doctor/src/components/settingsModals/pages/account/SettingsAccount2FAEmailEnableBackupCodesPage.tsx
@@ -13,7 +13,7 @@ const SettingsAccount2FAEmailEnableBackupCodesPage = (
 	selectedPageStack: string[],
 	onNext: () => void,
 ): SettingsPageType => {
-	const [backupCodes, setBackupCodes] = useState<string[]>([
+	const defaultBackupCodes = [
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
@@ -24,7 +24,8 @@ const SettingsAccount2FAEmailEnableBackupCodesPage = (
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
-	]);
+	];
+	const [backupCodes, setBackupCodes] = useState<string[]>(defaultBackupCodes);
 
 	const [triggerGenerateBackupCodes] = useGenerateBackupCodesMutation();
 
@@ -48,7 +49,13 @@ const SettingsAccount2FAEmailEnableBackupCodesPage = (
 		sections: [],
 		bodyContent: <BackupCodes backupCodes={backupCodes} />,
 		footerPrimaryButton: (
-			<Button w="100%" onClick={onNext}>
+			<Button
+				w="100%"
+				onClick={() => {
+					setBackupCodes(defaultBackupCodes);
+					onNext();
+				}}
+			>
 				Mes codes sont sauvegardés
 			</Button>
 		),

--- a/edgar-doctor/src/components/settingsModals/pages/account/SettingsAccountBackupCodesGeneratePage.tsx
+++ b/edgar-doctor/src/components/settingsModals/pages/account/SettingsAccountBackupCodesGeneratePage.tsx
@@ -10,7 +10,7 @@ import { useGenerateBackupCodesMutation } from 'services/request/2fa';
 import ShieldIllustration from 'assets/illustrations/ShieldIllustration';
 
 const SettingsAccountBackupCodesGeneratePage = (selectedPageStack: string[], onNext: () => void): SettingsPageType => {
-	const [backupCodes, setBackupCodes] = useState<string[]>([
+	const defaultBackupCodes = [
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
@@ -19,7 +19,10 @@ const SettingsAccountBackupCodesGeneratePage = (selectedPageStack: string[], onN
 		'XXXX XXXX',
 		'XXXX XXXX',
 		'XXXX XXXX',
-	]);
+		'XXXX XXXX',
+		'XXXX XXXX',
+	];
+	const [backupCodes, setBackupCodes] = useState<string[]>(defaultBackupCodes);
 
 	const [triggerGenerateBackupCodes] = useGenerateBackupCodesMutation();
 
@@ -43,7 +46,13 @@ const SettingsAccountBackupCodesGeneratePage = (selectedPageStack: string[], onN
 		sections: [],
 		bodyContent: <BackupCodes backupCodes={backupCodes} />,
 		footerPrimaryButton: (
-			<Button w="100%" onClick={onNext}>
+			<Button
+				w="100%"
+				onClick={() => {
+					setBackupCodes(defaultBackupCodes);
+					onNext();
+				}}
+			>
 				Mes codes sont sauvegardés
 			</Button>
 		),

--- a/edgar-doctor/src/services/request/2fa.ts
+++ b/edgar-doctor/src/services/request/2fa.ts
@@ -68,7 +68,7 @@ const extendedApi = backendApi.injectEndpoints({
 				url: '/auth/creation_backup_code',
 				method: 'POST',
 			}),
-			invalidatesTags: ['doctor2faBackupCodes'],
+			invalidatesTags: ['doctor2faBackupCodes', 'doctor2faMethod'],
 			transformResponse: (response: { double_auth: string[] }) => response.double_auth,
 		}),
 
@@ -85,7 +85,7 @@ const extendedApi = backendApi.injectEndpoints({
 					country: device.country,
 					lastConnectedTime: device.date * 1000,
 				})) || [],
-			providesTags: ['doctor2faTrustedDevices'],
+			providesTags: ['doctor2faTrustedDevices', 'doctorDevice', 'doctor2faMethod'],
 		}),
 
 		getTrustedDeviceById: builder.query<DeviceType, string>({
@@ -99,7 +99,7 @@ const extendedApi = backendApi.injectEndpoints({
 				country: response.double_auth.country,
 				lastConnectedTime: response.double_auth.date * 1000,
 			}),
-			providesTags: ['doctor2faTrustedDevices'],
+			providesTags: ['doctor2faTrustedDevices', 'doctorDevice', 'doctor2faMethod'],
 		}),
 
 		addTrustedDevice: builder.mutation<void, string>({

--- a/edgar-doctor/src/services/request/devices.ts
+++ b/edgar-doctor/src/services/request/devices.ts
@@ -18,6 +18,7 @@ const extendedApi = backendApi.injectEndpoints({
 					country: device.country,
 					lastConnectedTime: device.date * 1000,
 				})) || [],
+			providesTags: ['doctorDevice'],
 		}),
 
 		getConnectedDeviceById: builder.query<DeviceType, string>({
@@ -31,6 +32,7 @@ const extendedApi = backendApi.injectEndpoints({
 				country: response.double_auth.country,
 				lastConnectedTime: response.double_auth.date * 1000,
 			}),
+			providesTags: ['doctorDevice'],
 		}),
 
 		removeDevice: builder.mutation<void, string>({


### PR DESCRIPTION
# Description

- Autoreload when disconnecting a device
- Autoreload of the trusted devices when adding mobile 2fa
- Autoreload on bakcup codes state when adding a 2fa method

### Click Up reference

[CU-86c13xfuq](https://app.clickup.com/t/86c13xfuq)

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the needed labels
- [X] I have linked this PR to a clickup task
- [X] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs