### PR TITLE
feat: app - Add loading until the NLP is up

### DIFF
--- a/edgar-app/src/services/request/simulation.ts
+++ b/edgar-app/src/services/request/simulation.ts
@@ -6,6 +6,11 @@ import { type SimulationChatDiagnoseDiagnosticType } from 'types/simulation/chat
 
 const extendedApi = backendApi.injectEndpoints({
 	endpoints: (builder) => ({
+		getNlpStatus: builder.query<boolean, void>({
+			query: () => '/nlp/status',
+			transformResponse: (response: { status: string }) => response.status === 'running',
+		}),
+
 		// Diagnostic mutations
 		initiateDiagnostic: builder.mutation<string, void>({
 			query: () => ({
@@ -26,4 +31,10 @@ const extendedApi = backendApi.injectEndpoints({
 		}),
 	}),
 });
-export const { useInitiateDiagnosticMutation, useDiagnoseDiagnosticMutation } = extendedApi;
+
+export const {
+	useGetNlpStatusQuery,
+	useLazyGetNlpStatusQuery,
+	useInitiateDiagnosticMutation,
+	useDiagnoseDiagnosticMutation,
+} = extendedApi;


### PR DESCRIPTION
# Description

- Add loading if the NLP is not up

### Click Up reference

[CU-86c13z4nd](https://app.clickup.com/t/86c13z4nd)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the needed labels
- [X] I have linked this PR to a clickup task
- [X] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
